### PR TITLE
Add a null check for CollectSignArguments

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Packet/s2c/DeclareCommands.cs
+++ b/MinecraftClient/Protocol/Handlers/Packet/s2c/DeclareCommands.cs
@@ -185,6 +185,9 @@ namespace MinecraftClient.Protocol.Handlers.packet.s2c
 
         private static void CollectSignArguments(int NodeIdx, string command, List<Tuple<string, string>> arguments)
         {
+            if (Nodes.Length == 0)
+                return;
+            
             CommandNode node = Nodes[NodeIdx];
             string last_arg = command;
             switch (node.Flags & 0x03)


### PR DESCRIPTION
i don't know what it does, but it sure doesn't throw an IndexOutOfBoundsException anymore